### PR TITLE
deployment configs changes

### DIFF
--- a/proposals/deployment-configs.md
+++ b/proposals/deployment-configs.md
@@ -5,37 +5,46 @@
 - Related proposals: [proposals/configs-api-v2-alt1.md](proposals/configs-api-v2-alt1.md)
 
 # Summary
-
-Director user should see deployment manifests in configs view (`bosh configs` command). Manifests should be referenced by an id by the deployment, similarly to how runtime and cloud configs are referenced.
+All configs associated with a deployments should be shown when displaying details about an individual deployment (e.g. with `bosh deployment -d <deployment name>`)
 
 # Motivation
-
-It's important to consolidate deployment manifest and other config concepts into a single API and UX. By using configs API to store deployment manifests, users will gain consistent visibility which configurations contribute to the deployment.
+Currently, there is only information about one of the configurations: the cloud config. In the list of all deployments (i.e. `bosh deployments`), we show either `outdated` or `latest` in an individual column. We are missing a lot of information here, namely runtime config and config names plus IDs.
 
 # Details
-
-- `bosh -d dep1 manifest` should return content of the reference deployment config
-- `bosh deployments` should have a column that specifies referenced configs
+- `bosh deployment -d <deployment name>` should have a column that specifies referenced configs
 
 ```bash
-$ bosh deployments
+$ bosh deployment -d dep1
 Name  Release(s)  Stemcell(s)  Config(s)                    Team(s)
-dep1  bosh-dns    bosh-...     122 deployment/dep1 latest   team1
-      ipsec                    123 cloud/default latest
-                               124 runtime/default
-                               125 runtime/ipsec
-dep2  bosh-dns    bosh-...     126 deployment/dep2 latest   team2
-      ipsec                    123 cloud/default latest
-                               124 runtime/default
+dep1  bosh-dns    bosh-...     123 cloud/default latest   team1
+      ipsec                    124 runtime/default
                                125 runtime/ipsec
 ```
 
-- update deployment event should record before and after configs
+### API changes
+
+* Introduce query parameter to exclude config information from list of deployments, as there are consumers which don't care about those `GET /deployments/:name?exclude_configs=true`
+  * Switch BOSH HM to use this query parameter
+* Introduce new API endpoint returning all configs associated with all deployments. Can be filtered for an individual deployment with a query parameter.
+  * The new endpoint no longer includes the `latest`/`outdated` marker, just config IDs
+```
+GET /deployment_configs?deployment=dep1
+
+[{id:"1", deployment:"dep1", config: {id:"123", type:"cloud", name:"default"}},
+ {id:"2", deployment:"dep1", config: {id:"124", type:"runtime", name:"default"}},
+ {id:"3", deployment:"dep1", config: {id:"125", type:"runtime", name:"ipsec"}}]
+
+```
+
+### CLI changes
+* CLI uses new endpoint for `bosh deployment -d <dep1>`
+* CLI removes `cloud config` column from `bosh deployments` and uses query parameter to exlude config information
+...
 
 # Drawbacks
 
-- `latest` identifiers will continue to remain latest
+...
 
 # Unresolved questions
 
-- which parts of the Director rely on previously saved version of a deployment manifest
+...

--- a/proposals/manifest-as-config.md
+++ b/proposals/manifest-as-config.md
@@ -1,0 +1,37 @@
+- State: discussing
+- Start date: ?
+- End date: ?
+- Docs: ?
+- Related proposals: [proposals/deployment-configs.md](proposals/deployment-configs.md)
+
+# Summary
+
+Director user should see deployment manifests in configs view (`bosh configs` command). Manifests should be referenced by an id by the deployment, similarly to how runtime and cloud configs are referenced.
+
+# Motivation
+
+It's important to consolidate deployment manifest and other config concepts into a single API and UX. By using configs API to store deployment manifests, users will gain consistent visibility which configurations contribute to the deployment.
+
+# Details
+
+- `bosh -d dep1 manifest` should return content of the reference deployment config
+- `bosh deployments` should have a column that includes the deployment manifest in the referenced configs
+
+```bash
+$ bosh deployment -d dep1
+Name  Release(s)  Stemcell(s)  Config(s)                    Team(s)
+dep1  bosh-dns    bosh-...     122 deployment/dep1 latest   team1
+      ipsec                    123 cloud/default latest
+                               124 runtime/default
+                               125 runtime/ipsec
+```
+
+- update deployment event should record before and after configs
+
+# Drawbacks
+
+- `latest` identifiers will continue to remain latest
+
+# Unresolved questions
+
+- which parts of the Director rely on previously saved version of a deployment manifest


### PR DESCRIPTION
* renames old `deployment-configs` to `manifest-as-config`
* introduces new proposal to actually display all configs associated with a deployment as `deployments-configs`